### PR TITLE
[QI2-989] Minimise member ID logging

### DIFF
--- a/quantuminspire/cli/command_list.py
+++ b/quantuminspire/cli/command_list.py
@@ -329,6 +329,7 @@ def login(
     tokens = auth_session.poll_for_tokens()
     settings.store_tokens(host_url, tokens)
     typer.echo("Login successful!")
+    typer.echo(f"Using member ID {settings.auths[host].team_member_id}")
 
 
 @app.command("logout")

--- a/quantuminspire/util/configuration.py
+++ b/quantuminspire/util/configuration.py
@@ -177,7 +177,6 @@ class Settings(BaseSettings):  # pylint: disable=too-few-public-methods
             members = members_page.items
             if len(members) == 1:
                 member_id = members[0].id
-                typer.echo(f"Using member ID {member_id}")
                 return cast(int, member_id)
 
             typer.echo("Choose a member ID from the list for project configuration.")
@@ -191,7 +190,6 @@ class Settings(BaseSettings):  # pylint: disable=too-few-public-methods
                     member_id = int(input("Please enter one of the given ids: "))
                     if member_id not in member_ids:
                         raise ValueError
-                    typer.echo(f"Using member ID {member_id}")
                     return cast(int, member_id)
                 except ValueError:
                     typer.echo("Invalid input. Please enter a valid id or CTRL + C to cancel.")


### PR DESCRIPTION
member_id now only logged once, when logging in. 

Scanned through the code and ran different scenarios using the SDK, but couldnt find any other logging that's unnecessary or troublesome during debugging. 